### PR TITLE
Speed up for creating graph statistics

### DIFF
--- a/create.py
+++ b/create.py
@@ -8,7 +8,7 @@ def execute(filename):
   cursor = connection.cursor()
   cursor.execute(query)
 
-tables = ["bibliography_items.sql", "bibliography_values.sql", "comments.sql", "dependencies.sql", "macros.sql", "sections.sql", "statistics.sql", "tags.sql", "tags_search.sql"]
+tables = ["bibliography_items.sql", "bibliography_values.sql", "comments.sql", "dependencies.sql", "macros.sql", "sections.sql", "statistics.sql", "tags.sql", "tags_search.sql", "graphs.sql"]
 indices = "indices.sql"
 
 if os.path.isfile("stacks.sqlite"):

--- a/database/graphs.sql
+++ b/database/graphs.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "graphs" (
+  "tag" VARCHAR PRIMARY KEY NOT NULL,
+  "node_count" INTEGER,
+  "edge_count" INTEGER,
+  "total_edge_count" INTEGER,
+  "chapter_count" INTEGER,
+  "section_count" INTEGER,
+  "use_count" INTEGER,
+  "indirect_use_count" INTEGER
+)

--- a/graphs.py
+++ b/graphs.py
@@ -1,20 +1,23 @@
 import graphs.generate
 
 
-print "Generating the force-directed graphs"
-graphs.generate.generateForceDirectedGraphs()
+#print "Generating the force-directed graphs"
+#graphs.generate.generateForceDirectedGraphs()
 
-print "Generating the cluster graphs"
-graphs.generate.generateClusterGraphs()
+#print "Generating the cluster graphs"
+#graphs.generate.generateClusterGraphs()
 
-print "Generating the collapsible graphs"
-graphs.generate.generateCollapsibleGraphs()
+#print "Generating the collapsible graphs"
+#graphs.generate.generateCollapsibleGraphs()
 
 #graphs.generate.scatter()
-print "\nClearing the dependencies table"
-graphs.generate.clearDependencies()
-print "Inserting dependencies"
-graphs.generate.insertDependencies()
+#print "\nClearing the dependencies table"
+#graphs.generate.clearDependencies()
+#print "Inserting dependencies"
+#graphs.generate.insertDependencies()
 
-print "\nCreating various graph related statistics"
-graphs.generate.updateCounts()
+#print "\nCreating various graph related statistics"
+#graphs.generate.updateCounts()
+
+print "Do all the graph stuff at once!"
+graphs.generate.allAtOnce()


### PR DESCRIPTION
`python graphs.py` now runs in 5m on my home machine.

There are some drawbacks to this method, the main one being that we have
top run all the parts consequentially (and we cannot run them one by one
to test for errors for example). Also, the parts have to be run in the correct
order.

Moreover the information is now stored in a separate database table called
graphs, and hence the corresponding code in stacks-website has to be
modified to make use of this.
